### PR TITLE
feat: bittwister sample code added to the app sync test

### DIFF
--- a/celestia_app/main_test.go
+++ b/celestia_app/main_test.go
@@ -2,11 +2,13 @@ package celestia_app
 
 import (
 	"fmt"
-	"github.com/celestiaorg/knuu/pkg/knuu"
-	"github.com/sirupsen/logrus"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -100,4 +102,12 @@ func prepareInstances(m *testing.M) {
 	}
 
 	Instances["full"] = full
+}
+
+func forwardBitTwisterPort(t *testing.T, i *knuu.Instance) {
+	fwdBtPort, err := i.PortForwardTCP(i.BitTwister.Port())
+	require.NoError(t, err, "Error port forwarding")
+	i.BitTwister.SetPort(fwdBtPort)
+	i.BitTwister.SetNewClientByIPAddr("http://localhost")
+	t.Logf("BitTwister listening on http://localhost:%d", fwdBtPort)
 }

--- a/celestia_app/pool_sync_test.go
+++ b/celestia_app/pool_sync_test.go
@@ -1,10 +1,15 @@
 package celestia_app
 
 import (
-	"github.com/celestiaorg/knuu-example/celestia_app/utils"
-	"github.com/celestiaorg/knuu/pkg/knuu"
+	"context"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/celestiaorg/knuu-example/celestia_app/utils"
+	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPoolSync(t *testing.T) {
@@ -65,6 +70,7 @@ func TestPoolSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error waiting for validator to be running: %v", err)
 	}
+
 	persistentPeers, err := utils.GetPersistentPeers(executor, []*knuu.Instance{validator})
 	if err != nil {
 		t.Fatalf("Error getting persistent peers: %v", err)
@@ -77,6 +83,7 @@ func TestPoolSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating pool: %v", err)
 	}
+
 	err = fullNodes.Start()
 	if err != nil {
 		t.Fatalf("Error starting full nodes: %v", err)
@@ -101,4 +108,112 @@ func TestPoolSync(t *testing.T) {
 			t.Fatalf("Error waiting for full node to reach block height 3: %v", err)
 		}
 	}
+}
+
+// TestPoolSync_WithTrafficShape tests if a restricted full node takes longer to sync than a full node
+// This is just a sample code to demonstrate how to use the bandwidth shaping feature
+// Feel free to modify it to suit your needs
+func TestPoolSync_WithTrafficShape(t *testing.T) {
+	t.Parallel()
+	// Setup
+
+	const targetHeight = 20
+
+	executor, err := knuu.NewExecutor()
+	require.NoError(t, err, "Error creating executor")
+
+	validator, err := Instances["validator"].Clone()
+	require.NoError(t, err, "Error cloning validator instance")
+
+	full, err := Instances["full"].CloneWithName("full")
+	require.NoError(t, err, "Error cloning full node instance")
+
+	fullRestricted, err := Instances["full"].CloneWithName("full-restricted")
+	require.NoError(t, err, "Error cloning restricted full node instance")
+
+	t.Cleanup(func() {
+		// Cleanup
+		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
+			t.Log("Skipping cleanup")
+			return
+		}
+
+		require.NoError(t, executor.Destroy(), "Error destroying executor")
+
+		// These checks are added to avoid errors when the test fails
+		// before the instances are started
+		if validator.IsInState(knuu.Started) {
+			require.NoError(t, validator.Destroy(), "Error destroying validator")
+		}
+
+		if full.IsInState(knuu.Started) {
+			require.NoError(t, full.Destroy(), "Error destroying full")
+		}
+
+		if fullRestricted.IsInState(knuu.Started) {
+			require.NoError(t, fullRestricted.Destroy(), "Error destroying restricted full")
+		}
+	})
+
+	// Test logic
+	require.NoError(t, validator.Start(), "Error starting validator")
+	err = utils.WaitForHeight(executor, validator, 1)
+	require.NoError(t, err, "Error waiting for validator to reach block height 1")
+
+	persistentPeers, err := utils.GetPersistentPeers(executor, []*knuu.Instance{validator})
+	require.NoError(t, err, "Error getting persistent peers")
+
+	err = full.SetArgs("start", "--home=/root/.celestia-app", "--rpc.laddr=tcp://0.0.0.0:26657", "--p2p.persistent_peers", persistentPeers)
+	require.NoError(t, err, "Error setting args for full node")
+
+	err = fullRestricted.SetArgs("start", "--home=/root/.celestia-app", "--rpc.laddr=tcp://0.0.0.0:26657", "--p2p.persistent_peers", persistentPeers)
+	require.NoError(t, err, "Error setting args for restricted full node")
+
+	// Wait until validator reaches the target block height
+	t.Logf("Waiting for validator to reach block height %d", targetHeight)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+	err = utils.WaitForHeightWithContext(ctx, executor, validator, targetHeight)
+	require.NoError(t, err, "Error waiting for validator to reach block height %d", targetHeight)
+
+	noRestrictionElapsed := time.Duration(0)
+	{
+		require.NoError(t, full.Start(), "Error starting full node")
+
+		startTime := time.Now().UnixNano()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		defer cancel()
+		err = utils.WaitForHeightWithContext(ctx, executor, full, targetHeight)
+		require.NoError(t, err, "Error waiting for full node to reach block height %d", targetHeight)
+
+		endTime := time.Now().UnixNano()
+		noRestrictionElapsed = time.Duration(endTime - startTime)
+		t.Logf("Elapsed time for full node without traffic shaping: %f seconds", noRestrictionElapsed.Seconds())
+	}
+
+	restrictedElapsed := time.Duration(0)
+	{
+		require.NoError(t, fullRestricted.EnableBitTwister(), "Error enabling BitTwister")
+		require.NoError(t, fullRestricted.Start(), "Error starting restricted full node")
+		forwardBitTwisterPort(t, fullRestricted)
+
+		startTime := time.Now().UnixNano()
+
+		// Set bandwidth limit for Restricted full node and then sync it with the validator
+		err = fullRestricted.SetBandwidthLimit(10 * 1000) // 10kbps
+		require.NoError(t, err, "Error setting bandwidth limit for fullRestricted")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		defer cancel()
+		err = utils.WaitForHeightWithContext(ctx, executor, fullRestricted, targetHeight)
+		require.NoError(t, err, "Error waiting for restricted full node to reach block height %d", targetHeight)
+
+		endTime := time.Now().UnixNano()
+		restrictedElapsed = time.Duration(endTime - startTime)
+		t.Logf("Elapsed time for restricted full node with traffic shaping: %f seconds", restrictedElapsed.Seconds())
+	}
+
+	// Check if restricted full node took longer than full node
+	assert.Greater(t, restrictedElapsed, noRestrictionElapsed, "full node took longer than restricted full node to sync")
 }

--- a/celestia_app/utils/utils.go
+++ b/celestia_app/utils/utils.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
+	"context"
 	"fmt"
-	"github.com/celestiaorg/knuu/pkg/knuu"
 	"time"
+
+	"github.com/celestiaorg/knuu/pkg/knuu"
 )
 
 type JSONRPCError struct {
@@ -22,7 +24,10 @@ func getStatus(executor *knuu.Executor, app *knuu.Instance) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error getting node ip: %w", err)
 	}
-	status, err := executor.ExecuteCommand("wget", "-q", "-O", "-", fmt.Sprintf("%s:26657/status", nodeIP))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	status, err := executor.ExecuteCommandWithContext(ctx, "wget", "-q", "-O", "-", fmt.Sprintf("%s:26657/status", nodeIP))
 	if err != nil {
 		return "", fmt.Errorf("error executing command: %w", err)
 	}
@@ -55,46 +60,38 @@ func GetHeight(executor *knuu.Executor, app *knuu.Instance) (int64, error) {
 }
 
 func WaitForHeight(executor *knuu.Executor, app *knuu.Instance, height int64) error {
-	timeout := time.After(5 * time.Minute)
-	tick := time.Tick(1 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	return WaitForHeightWithContext(ctx, executor, app, height)
+}
 
-	maxRetries := 5
+func WaitForHeightWithContext(ctx context.Context, executor *knuu.Executor, app *knuu.Instance, height int64) error {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {
-		case <-timeout:
-			return fmt.Errorf("timeout waiting for height %d", height)
-		case <-tick:
-			var blockHeight int64
-			var err error
-			for retries := 0; retries < maxRetries; retries++ {
-				status, err := getStatus(executor, app)
-				if err != nil {
-					return fmt.Errorf("error getting status: %v", err)
-				}
-				blockHeight, err = latestBlockHeightFromStatus(status)
-				if err != nil {
-					return fmt.Errorf("error getting block height: %w", err)
-				}
-				if err != nil {
-					if _, ok := err.(*JSONRPCError); !ok {
-						// If the error is not a JSONRPCError, stop and return it
-						return fmt.Errorf("error getting block height: %w", err)
-					}
-					// If the error is a JSONRPCError, sleep and then retry
-					if retries < maxRetries-1 {
-						time.Sleep(1 * time.Second)
-					}
-				} else {
-					// If no error, break the retry loop
-					break
-				}
+		case <-ctx.Done():
+			if ctx.Err() != nil {
+				return fmt.Errorf("operation canceled: %v", ctx.Err())
 			}
+			return nil
+		case <-ticker.C:
+			status, err := getStatus(executor, app)
 			if err != nil {
+				return fmt.Errorf("error getting status: %v", err)
+			}
+
+			blockHeight, err := latestBlockHeightFromStatus(status)
+			if err != nil {
+				if _, ok := err.(*JSONRPCError); ok {
+					// Retry if it's a temporary API error
+					continue
+				}
 				return fmt.Errorf("error getting block height: %w", err)
 			}
+
 			if blockHeight >= height {
-				// Reached block height `height`
 				return nil
 			}
 		}


### PR DESCRIPTION
This PR adds a traffic shape test to the app (`TestPoolSync_WithTrafficShape`).

It basically creates one validator and two full nodes out of which one is not restricted and the other one has a limitation on bandwidth and then let them sync and measures the elapsed time of each and compares them.

This code is a sample code to show app developers how to apply traffic shape conditions on their tests using BitTwister.