### PR TITLE
fix: bittwister test timeout failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@ test-basic:
 	go test -v ./basic -timeout 120m
 
 test-bittwister-packetloss:
-	go test -v ./basic --run=TestBittwister_Packetloss -timeout 30m -count=1
+	KNUU_TIMEOUT=120m go test -v ./basic --run=TestBittwister_Packetloss -timeout 60m -count=1
 
 test-bittwister-bandwidth:
-	go test -v ./basic --run=TestBittwister_Bandwidth -timeout 30m -count=1
+	KNUU_TIMEOUT=120m go test -v ./basic --run=TestBittwister_Bandwidth -timeout 60m -count=1
 
 test-bittwister-latency:
-	go test -v ./basic --run=TestBittwister_Latency -timeout 30m -count=1
+	KNUU_TIMEOUT=120m go test -v ./basic --run=TestBittwister_Latency -timeout 60m -count=1
 
 test-bittwister-jitter:
-	go test -v ./basic --run=TestBittwister_Jitter -timeout 30m -count=1
+	KNUU_TIMEOUT=120m go test -v ./basic --run=TestBittwister_Jitter -timeout 60m -count=1
 
 test-celestia-app:
 	go test -v ./celestia_app
@@ -20,6 +20,6 @@ test-celestia-node:
 	go test -v ./celestia_node
 
 test-all:
-	go test -v ./... -timeout 120m
+	KNUU_TIMEOUT=300m go test -v ./... -timeout 120m
 
 .PHONY: test-all test-basic test-bittwister-packetloss test-bittwister-bandwidth test-bittwister-latency test-bittwister-jitter test-celestia-app test-celestia-node

--- a/basic/bittwister_test.go
+++ b/basic/bittwister_test.go
@@ -29,10 +29,7 @@ func TestBittwister_Bandwidth(t *testing.T) {
 		iperfTestDuration    = 45 * time.Second
 		iperfParallelClients = 4
 		commandTimeout       = 60 * time.Minute
-		knuuTimeout          = 3 * time.Hour
 	)
-
-	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	iperfMother, err := knuu.NewInstance("iperf")
 	require.NoError(t, err, "Error creating instance")
@@ -170,10 +167,7 @@ func TestBittwister_Packetloss(t *testing.T) {
 		numOfPingPackets = 1000
 		packetTimeout    = 1 * time.Second
 		commandTimeout   = 60 * time.Minute
-		knuuTimeout      = 3 * time.Hour
 	)
-
-	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	mother, err := knuu.NewInstance("mother")
 	require.NoError(t, err, "Error creating instance")
@@ -219,6 +213,10 @@ func TestBittwister_Packetloss(t *testing.T) {
 	require.NoError(t, executor.Start(), "Error starting executor instance")
 
 	// Perform the test
+
+	fmt.Print("Sleeping for 50 minutes to allow the BitTwister to stabilize...")
+	time.Sleep(50 * time.Minute)
+	fmt.Println("Done waiting.")
 
 	tt := []struct {
 		name                 string
@@ -310,10 +308,7 @@ func TestBittwister_Latency(t *testing.T) {
 		numOfPingPackets = 100
 		packetTimeout    = 1 * time.Second
 		commandTimeout   = 60 * time.Minute
-		knuuTimeout      = 3 * time.Hour
 	)
-
-	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	mother, err := knuu.NewInstance("mother")
 	require.NoError(t, err, "Error creating instance")
@@ -466,10 +461,7 @@ func TestBittwister_Jitter(t *testing.T) {
 		numOfPingPackets = 100
 		packetTimeout    = 1 * time.Second
 		commandTimeout   = 60 * time.Minute
-		knuuTimeout      = 3 * time.Hour
 	)
-
-	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	mother, err := knuu.NewInstance("mother")
 	require.NoError(t, err, "Error creating instance")

--- a/basic/bittwister_test.go
+++ b/basic/bittwister_test.go
@@ -288,7 +288,7 @@ func TestBittwister_Packetloss(t *testing.T) {
 			t.Logf("Test took %d seconds", int64(elapsed.Seconds()))
 
 			gotPacketloss, err := strconv.ParseFloat(output, 64)
-			require.NoError(t, err, "Error parsing output")
+			require.NoError(t, err, fmt.Sprintf("Error parsing output: `%s`", output))
 
 			deviationPercent := math.Abs(gotPacketloss - float64(tc.targetPacketlossRate))
 			assert.LessOrEqual(t, deviationPercent, float64(tc.tolerancePercent), "Deviation is too high")

--- a/basic/bittwister_test.go
+++ b/basic/bittwister_test.go
@@ -29,7 +29,10 @@ func TestBittwister_Bandwidth(t *testing.T) {
 		iperfTestDuration    = 45 * time.Second
 		iperfParallelClients = 4
 		commandTimeout       = 60 * time.Minute
+		knuuTimeout          = 3 * time.Hour
 	)
+
+	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	iperfMother, err := knuu.NewInstance("iperf")
 	require.NoError(t, err, "Error creating instance")
@@ -68,6 +71,10 @@ func TestBittwister_Bandwidth(t *testing.T) {
 	require.NoError(t, iperfServer.Start(), "Error starting iperf-server instance")
 
 	forwardBitTwisterPort(t, iperfServer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	require.NoError(t, iperfServer.BitTwister.WaitForStart(ctx), "Error waiting for BitTwister to start")
 
 	require.NoError(t, iperfClient.Start(), "Error starting iperf-client instance")
 
@@ -163,7 +170,10 @@ func TestBittwister_Packetloss(t *testing.T) {
 		numOfPingPackets = 1000
 		packetTimeout    = 1 * time.Second
 		commandTimeout   = 60 * time.Minute
+		knuuTimeout      = 3 * time.Hour
 	)
+
+	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	mother, err := knuu.NewInstance("mother")
 	require.NoError(t, err, "Error creating instance")
@@ -202,6 +212,10 @@ func TestBittwister_Packetloss(t *testing.T) {
 
 	forwardBitTwisterPort(t, target)
 
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	require.NoError(t, target.BitTwister.WaitForStart(ctx), "Error waiting for BitTwister to start")
+
 	require.NoError(t, executor.Start(), "Error starting executor instance")
 
 	// Perform the test
@@ -210,11 +224,12 @@ func TestBittwister_Packetloss(t *testing.T) {
 		name                 string
 		targetPacketlossRate int32
 		tolerancePercent     int
-	}{{
-		name:                 "10%",
-		targetPacketlossRate: 10,
-		tolerancePercent:     50,
-	},
+	}{
+		{
+			name:                 "10%",
+			targetPacketlossRate: 10,
+			tolerancePercent:     50,
+		},
 		{
 			name:                 "20%",
 			targetPacketlossRate: 20,
@@ -275,7 +290,7 @@ func TestBittwister_Packetloss(t *testing.T) {
 			gotPacketloss, err := strconv.ParseFloat(output, 64)
 			require.NoError(t, err, "Error parsing output")
 
-			deviationPercent := math.Abs(gotPacketloss-float64(tc.targetPacketlossRate)) / float64(tc.targetPacketlossRate) * 100
+			deviationPercent := math.Abs(gotPacketloss - float64(tc.targetPacketlossRate))
 			assert.LessOrEqual(t, deviationPercent, float64(tc.tolerancePercent), "Deviation is too high")
 
 			t.Logf("Packetloss expected: %v%% \tgot: %.2f%% \tdeviation: %.2f%% \ttolerance: %v%%",
@@ -295,7 +310,10 @@ func TestBittwister_Latency(t *testing.T) {
 		numOfPingPackets = 100
 		packetTimeout    = 1 * time.Second
 		commandTimeout   = 60 * time.Minute
+		knuuTimeout      = 3 * time.Hour
 	)
+
+	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	mother, err := knuu.NewInstance("mother")
 	require.NoError(t, err, "Error creating instance")
@@ -333,6 +351,10 @@ func TestBittwister_Latency(t *testing.T) {
 	require.NoError(t, target.Start(), "Error starting target instance")
 
 	forwardBitTwisterPort(t, target)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	require.NoError(t, target.BitTwister.WaitForStart(ctx), "Error waiting for BitTwister to start")
 
 	require.NoError(t, executor.Start(), "Error starting executor instance")
 
@@ -444,7 +466,10 @@ func TestBittwister_Jitter(t *testing.T) {
 		numOfPingPackets = 100
 		packetTimeout    = 1 * time.Second
 		commandTimeout   = 60 * time.Minute
+		knuuTimeout      = 3 * time.Hour
 	)
+
+	require.NoError(t, os.Setenv("KNUU_TIMEOUT", knuuTimeout.String()), "Error setting knuu timeout")
 
 	mother, err := knuu.NewInstance("mother")
 	require.NoError(t, err, "Error creating instance")
@@ -482,6 +507,10 @@ func TestBittwister_Jitter(t *testing.T) {
 	require.NoError(t, target.Start(), "Error starting target instance")
 
 	forwardBitTwisterPort(t, target)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	require.NoError(t, target.BitTwister.WaitForStart(ctx), "Error waiting for BitTwister to start")
 
 	require.NoError(t, executor.Start(), "Error starting executor instance")
 

--- a/basic/bittwister_test.go
+++ b/basic/bittwister_test.go
@@ -213,11 +213,6 @@ func TestBittwister_Packetloss(t *testing.T) {
 	require.NoError(t, executor.Start(), "Error starting executor instance")
 
 	// Perform the test
-
-	fmt.Print("Sleeping for 50 minutes to allow the BitTwister to stabilize...")
-	time.Sleep(50 * time.Minute)
-	fmt.Println("Done waiting.")
-
 	tt := []struct {
 		name                 string
 		targetPacketlossRate int32


### PR DESCRIPTION
BitTwister tests failed sometimes and gave some none sense errors like the following:

`command terminated with exit code 137`
```
error forwarding port 9009 to pod d26ecf89ebfcb0e1291e72459af733cecbb7d559fc6bd8e72f79ca2ad02bc68c, uid : container not running (d26ecf89ebfcb0e1291e72459af733cecbb7d559fc6bd8e72f79ca2ad02bc68c)
```
```
error stopping packetloss for instance 'target-b18ea2ee': postResource: Post "http://localhost:35211/api/v1/packetloss/stop": EOF
```

I tried multiple ways to find out what causes the issue. Tried to log the resource usage as I guessed the instance with high ping volumes, might run out of memory and k8s removes it. After some analysis, it came out that was not the case.

Another test was to put a sleep timer right before the test and see how long it can wait and then fails. I found out on my machine with minikube, if the timer is set to `42 minutes` it fails, for less than that, it works well. 

So there must be something related to the timeout somewhere. It turned out that knuu has a `timeout-handler` which is a useful thing to remove unused pods and free up resources, the default value for that timeout is `60 minutes` and since BitTwister tests are large and sometimes take longer than an hour, they would fail as there is no instance to run the commands on. So the simpler workaround is to increase that timeout right before the test starts.

